### PR TITLE
ENG-29107: Add withJavaProperty to forward -D system properties to Vo…

### DIFF
--- a/volt-testcontainer/src/main/java/org/voltdbtest/testcontainer/VoltDBCluster.java
+++ b/volt-testcontainer/src/main/java/org/voltdbtest/testcontainer/VoltDBCluster.java
@@ -634,6 +634,30 @@ public class VoltDBCluster {
     }
 
     /**
+     * Adds a {@code -D} JVM system property that will be forwarded to every VoltDB server JVM
+     * in the cluster via the {@code VOLTDB_OPTS} environment variable. Subsequent calls with
+     * the same key overwrite the previous value on each container. Properties take effect on
+     * the next container start.
+     * <p>
+     * Useful for fault-injection or knob tweaking that VoltDB reads from JVM system properties
+     * (e.g. streaming-snapshot throttle, test-only behavior flags).
+     *
+     * @param key   the property name (must be non-null and non-empty, no whitespace)
+     * @param value the property value (must be non-null, no whitespace; may be empty)
+     * @return this cluster instance for method chaining
+     * @throws NullPointerException     if {@code key} or {@code value} is null
+     * @throws IllegalArgumentException if {@code key} is empty or {@code key}/{@code value}
+     *                                  contains whitespace
+     * @see VoltDBContainer#withJavaProperty(String, String)
+     */
+    public VoltDBCluster withJavaProperty(String key, String value) {
+        for (VoltDBContainer voltDBContainer : containers()) {
+            voltDBContainer.withJavaProperty(key, value);
+        }
+        return this;
+    }
+
+    /**
      * Enables or disables command logging in the deployment configuration for all containers.
      * Command logging is not supported by the VoltDB developer edition, and is automatically
      * disabled when a developer edition image is detected. Use this method to override
@@ -832,7 +856,7 @@ public class VoltDBCluster {
         return this;
     }
 
-    private Collection<VoltDBContainer> containers() {
+    Collection<VoltDBContainer> containers() {
         return containers.values();
     }
 }

--- a/volt-testcontainer/src/main/java/org/voltdbtest/testcontainer/VoltDBContainer.java
+++ b/volt-testcontainer/src/main/java/org/voltdbtest/testcontainer/VoltDBContainer.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -158,6 +159,12 @@ public class VoltDBContainer extends GenericContainer<VoltDBContainer> {
     private String deployment;
 
     /**
+     * Extra {@code -D} JVM system properties to forward to the VoltDB server JVM via
+     * the {@code VOLTDB_OPTS} environment variable. Insertion order is preserved.
+     */
+    private final Map<String, String> javaProperties = new LinkedHashMap<>();
+
+    /**
      * Creates a VoltDB container using a public, free Developer Edition container.
      * <p>
      * Does not add any jars to its extension directory.
@@ -276,10 +283,7 @@ public class VoltDBContainer extends GenericContainer<VoltDBContainer> {
 
         withEnv("VOLTDB_START_CONFIG", startCommand);
         withEnv("VOLTDB_CONFIG", "/etc/deployment.xml");
-        withEnv("VOLTDB_OPTS",
-                "-Dlog4j.configuration=file:///opt/voltdb/tools/kubernetes/console-log4j.xml "
-                + " --add-opens=java.base/java.net=ALL-UNNAMED"
-                + " --add-opens=java.base/java.lang.reflect=ALL-UNNAMED");
+        withEnv("VOLTDB_OPTS", buildVoltdbOpts());
 
         withNetworkMode(NETWORK.getId());
         withNetwork(NETWORK);
@@ -534,6 +538,57 @@ public class VoltDBContainer extends GenericContainer<VoltDBContainer> {
     public VoltDBContainer withExtraJarsDir(String extraJarsDir) {
         this.extraJarsDir = extraJarsDir;
         return this;
+    }
+
+    /**
+     * Adds a {@code -D} JVM system property that will be forwarded to the VoltDB server JVM
+     * via the {@code VOLTDB_OPTS} environment variable. Subsequent calls with the same key
+     * overwrite the previous value. Properties take effect on the next container start.
+     * <p>
+     * Values must not contain whitespace; the JVM splits {@code VOLTDB_OPTS} on spaces, so
+     * a value like {@code "a b"} would be parsed as two separate arguments.
+     *
+     * @param key   the property name (must be non-null and non-empty)
+     * @param value the property value (must be non-null; may be empty)
+     * @return this container instance for method chaining
+     * @throws NullPointerException     if {@code key} or {@code value} is null
+     * @throws IllegalArgumentException if {@code key} is empty or contains whitespace,
+     *                                  or if {@code value} contains whitespace
+     */
+    public VoltDBContainer withJavaProperty(String key, String value) {
+        Objects.requireNonNull(key, "key must not be null");
+        Objects.requireNonNull(value, "value must not be null");
+        if (key.isEmpty()) {
+            throw new IllegalArgumentException("key must not be empty");
+        }
+        if (containsWhitespace(key)) {
+            throw new IllegalArgumentException("key must not contain whitespace: " + key);
+        }
+        if (containsWhitespace(value)) {
+            throw new IllegalArgumentException("value must not contain whitespace: " + value);
+        }
+        this.javaProperties.put(key, value);
+        return this;
+    }
+
+    private static boolean containsWhitespace(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            if (Character.isWhitespace(s.charAt(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String buildVoltdbOpts() {
+        StringBuilder sb = new StringBuilder()
+                .append("-Dlog4j.configuration=file:///opt/voltdb/tools/kubernetes/console-log4j.xml ")
+                .append(" --add-opens=java.base/java.net=ALL-UNNAMED")
+                .append(" --add-opens=java.base/java.lang.reflect=ALL-UNNAMED");
+        for (Map.Entry<String, String> e : javaProperties.entrySet()) {
+            sb.append(" -D").append(e.getKey()).append('=').append(e.getValue());
+        }
+        return sb.toString();
     }
 
     private void handleLicenseSetup(String licensePath) {

--- a/volt-testcontainer/src/test/java/org/voltdbtest/testcontainer/VoltDBContainerTest.java
+++ b/volt-testcontainer/src/test/java/org/voltdbtest/testcontainer/VoltDBContainerTest.java
@@ -390,4 +390,161 @@ public class VoltDBContainerTest {
         assertThat(container.getExposedPorts())
                 .contains(VoltDBContainer.VOLTDB_CLIENT_PORT);
     }
+
+    @Test
+    void withJavaPropertyReturnsSameInstance() throws IOException {
+        // Given
+        VoltDBContainer container = createContainer();
+
+        // When
+        VoltDBContainer result = container.withJavaProperty("voltdb.test.flag", "true");
+
+        // Then
+        assertThat(result).isSameAs(container);
+    }
+
+    @Test
+    void withJavaPropertyAppendsToVoltdbOpts() throws IOException {
+        // Given
+        VoltDBContainer container = createContainer()
+                .withJavaProperty("voltdb.test.streamingSnapshot.failOnDemand", "true")
+                .withJavaProperty("custom.flag", "42");
+
+        // When
+        container.configure();
+
+        // Then — the env value should retain the base options and append both -D entries
+        // in insertion order.
+        String voltdbOpts = container.getEnvMap().get("VOLTDB_OPTS");
+        assertThat(voltdbOpts)
+                .as("base options must still be present")
+                .contains("-Dlog4j.configuration=")
+                .contains("--add-opens=java.base/java.net=ALL-UNNAMED")
+                .contains("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED");
+        assertThat(voltdbOpts)
+                .as("user-supplied properties must be appended")
+                .contains(" -Dvoltdb.test.streamingSnapshot.failOnDemand=true")
+                .contains(" -Dcustom.flag=42");
+        assertThat(voltdbOpts.indexOf(" -Dvoltdb.test.streamingSnapshot.failOnDemand=true"))
+                .as("insertion order must be preserved")
+                .isLessThan(voltdbOpts.indexOf(" -Dcustom.flag=42"));
+    }
+
+    @Test
+    void voltdbOptsHasNoExtraPropertiesByDefault() throws IOException {
+        // Given
+        VoltDBContainer container = createContainer();
+
+        // When
+        container.configure();
+
+        // Then — no extra -D entries beyond the hardcoded baseline
+        String voltdbOpts = container.getEnvMap().get("VOLTDB_OPTS");
+        assertThat(voltdbOpts).isNotNull();
+        assertThat(countSubstring(voltdbOpts, " -D"))
+                .as("only the baseline log4j -D should appear when no user properties are set")
+                .isZero();
+        assertThat(voltdbOpts).startsWith("-Dlog4j.configuration=");
+    }
+
+    @Test
+    void withJavaPropertyOverwritesPreviousValueForSameKey() throws IOException {
+        // Given
+        VoltDBContainer container = createContainer()
+                .withJavaProperty("voltdb.test.flag", "first")
+                .withJavaProperty("voltdb.test.flag", "second");
+
+        // When
+        container.configure();
+
+        // Then
+        String voltdbOpts = container.getEnvMap().get("VOLTDB_OPTS");
+        assertThat(voltdbOpts).contains(" -Dvoltdb.test.flag=second");
+        assertThat(voltdbOpts).doesNotContain("=first");
+    }
+
+    @Test
+    void withJavaPropertyAllowsEmptyValue() throws IOException {
+        // Given
+        VoltDBContainer container = createContainer()
+                .withJavaProperty("voltdb.test.flag", "");
+
+        // When
+        container.configure();
+
+        // Then
+        String voltdbOpts = container.getEnvMap().get("VOLTDB_OPTS");
+        assertThat(voltdbOpts).contains(" -Dvoltdb.test.flag=");
+    }
+
+    @Test
+    void withJavaPropertyRejectsNullKey() throws IOException {
+        VoltDBContainer container = createContainer();
+        assertThatThrownBy(() -> container.withJavaProperty(null, "v"))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void withJavaPropertyRejectsNullValue() throws IOException {
+        VoltDBContainer container = createContainer();
+        assertThatThrownBy(() -> container.withJavaProperty("k", null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void withJavaPropertyRejectsEmptyKey() throws IOException {
+        VoltDBContainer container = createContainer();
+        assertThatThrownBy(() -> container.withJavaProperty("", "v"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void withJavaPropertyRejectsWhitespaceInKey() throws IOException {
+        VoltDBContainer container = createContainer();
+        assertThatThrownBy(() -> container.withJavaProperty("bad key", "v"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void withJavaPropertyRejectsWhitespaceInValue() throws IOException {
+        VoltDBContainer container = createContainer();
+        assertThatThrownBy(() -> container.withJavaProperty("k", "bad value"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void clusterWithJavaPropertyFansOutToAllContainers() throws IOException {
+        // Given
+        Path fakeLicense = tempDir.resolve("license.xml");
+        Files.writeString(fakeLicense, "<license/>");
+        VoltDBCluster cluster = new VoltDBCluster(
+                fakeLicense.toAbsolutePath().toString(),
+                VoltDBContainer.DEV_IMAGE,
+                3,
+                1
+        );
+
+        // When
+        VoltDBCluster result = cluster.withJavaProperty("voltdb.test.fanout", "yes");
+
+        // Then
+        assertThat(result).isSameAs(cluster);
+        assertThat(cluster.containers()).hasSize(3);
+        for (VoltDBContainer c : cluster.containers()) {
+            c.configure();
+            assertThat(c.getEnvMap().get("VOLTDB_OPTS"))
+                    .as("each container in the cluster must receive the property")
+                    .contains(" -Dvoltdb.test.fanout=yes");
+        }
+    }
+
+    private static int countSubstring(String haystack, String needle) {
+        int count = 0;
+        int from = 0;
+        while ((from = haystack.indexOf(needle, from)) != -1) {
+            count++;
+            from += needle.length();
+        }
+        return count;
+    }
 }


### PR DESCRIPTION
…ltDB server JVM.

Adds VoltDBContainer.withJavaProperty(key, value) and a fan-out
  VoltDBCluster.withJavaProperty(key, value) that append -Dkey=value
  entries to VOLTDB_OPTS while preserving the existing log4j and
  --add-opens baseline. Useful for fault-injection and test-only knobs
  that VoltDB reads from JVM system properties.