### PR TITLE
ENG-29638: pull mutable "--latest" image tags on every container start

### DIFF
--- a/volt-testcontainer/src/main/java/org/voltdbtest/testcontainer/VoltDBContainer.java
+++ b/volt-testcontainer/src/main/java/org/voltdbtest/testcontainer/VoltDBContainer.java
@@ -12,6 +12,7 @@ import com.github.dockerjava.api.model.ContainerNetwork;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.PullPolicy;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
@@ -266,6 +267,17 @@ public class VoltDBContainer extends GenericContainer<VoltDBContainer> {
         this.extraJarsDir = extraJarsDir;
         this.deployment = deployment;
 
+        // A tag ending in "--latest" is mutable: the same tag string can point
+        // at different image digests on the registry over time. Testcontainers'
+        // default pull policy only pulls when the image is absent locally, so
+        // a cached copy from an earlier run can silently mask a registry update
+        // and the container ends up running a stale image. Force an always-pull
+        // for these tags only; pinned/immutable tags keep the default so tests
+        // don't re-pull on every invocation.
+        if (isMutableTag(image)) {
+            withImagePullPolicy(PullPolicy.alwaysPull());
+        }
+
         // disable command log if using dev edition
         if (isDevImage(image)) {
             this.commandLogEnabled = false;
@@ -273,6 +285,16 @@ public class VoltDBContainer extends GenericContainer<VoltDBContainer> {
 
         topicPublicInterface = hostId;
         drPublicInterface = hostId;
+    }
+
+    /**
+     * A mutable image tag is one whose string identity does not pin a specific
+     * image digest — the registry can update it under the same name over time.
+     * Callers that pass such a tag need an always-pull policy so a stale local
+     * cache can't mask a registry update.
+     */
+    public static boolean isMutableTag(String image) {
+        return image != null && image.endsWith("--latest");
     }
 
     @Override

--- a/volt-testcontainer/src/main/java/org/voltdbtest/testcontainer/VoltDBContainer.java
+++ b/volt-testcontainer/src/main/java/org/voltdbtest/testcontainer/VoltDBContainer.java
@@ -292,9 +292,31 @@ public class VoltDBContainer extends GenericContainer<VoltDBContainer> {
      * image digest — the registry can update it under the same name over time.
      * Callers that pass such a tag need an always-pull policy so a stale local
      * cache can't mask a registry update.
+     *
+     * <p>The recognised suffixes cover the tag conventions produced by the
+     * VoltDB image-build pipelines:
+     * <ul>
+     *   <li>{@code :latest} — Docker's global rolling tag; pushed on master.</li>
+     *   <li>{@code --latest} — per-branch rolling tag published by the
+     *       release-image and VMC-svc image builds.</li>
+     *   <li>{@code --debug} — per-branch rolling CI/debug tag published by
+     *       {@code 1_pre_check_and_build}.</li>
+     *   <li>{@code --dev} — per-branch rolling tag still used by the VMC-svc
+     *       dev image and by older release branches that predate the rename
+     *       of {@code --dev} to {@code --debug}.</li>
+     * </ul>
+     * Numbered variants (e.g. {@code --debug-142}, {@code --142}) and pinned
+     * released versions (e.g. {@code 15.3.0}) are treated as immutable and
+     * keep the testcontainers default pull policy.
      */
     public static boolean isMutableTag(String image) {
-        return image != null && image.endsWith("--latest");
+        if (image == null) {
+            return false;
+        }
+        return image.endsWith(":latest")
+                || image.endsWith("--latest")
+                || image.endsWith("--debug")
+                || image.endsWith("--dev");
     }
 
     @Override

--- a/volt-testcontainer/src/test/java/PullPolicyIT.java
+++ b/volt-testcontainer/src/test/java/PullPolicyIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025-2026 Volt Active Data Inc.
+ *
+ * Use of this source code is governed by an MIT
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+import org.junit.jupiter.api.Test;
+import org.voltdbtest.testcontainer.VoltDBContainer;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the mutable-tag classification that drives whether
+ * {@link VoltDBContainer} applies an always-pull image pull policy at
+ * construction time.
+ *
+ * <p>Mutable tags (ending in {@code --latest}) must return {@code true} so
+ * that the container is forced to re-pull on every run; every other tag shape
+ * must return {@code false} so that pinned tags keep the testcontainers
+ * default (pull only when absent locally).
+ *
+ * <p>Placed as a failsafe integration test ({@code *IT.java}) because the
+ * module's pom configures failsafe only. No Docker daemon interaction is
+ * required for the assertions themselves.
+ */
+public class PullPolicyIT {
+
+    @Test
+    public void latestSuffixIsMutable() {
+        assertTrue(VoltDBContainer.isMutableTag("voltdb/voltdb-enterprise-dev:never-released--latest"),
+                "A tag ending in --latest must be classified as mutable");
+        assertTrue(VoltDBContainer.isMutableTag("some-image:main--latest"),
+                "Any tag ending in --latest must be classified as mutable regardless of branch prefix");
+    }
+
+    @Test
+    public void pinnedTagIsNotMutable() {
+        assertFalse(VoltDBContainer.isMutableTag("voltdb/voltdb-enterprise:14.3.3"),
+                "A pinned version tag must not be classified as mutable");
+        assertFalse(VoltDBContainer.isMutableTag("voltdb/voltdb-enterprise:master--debug-1234"),
+                "A build-number tag must not be classified as mutable");
+    }
+
+    @Test
+    public void bareLatestIsNotMutable() {
+        // The classification is intentionally strict: only the "--latest"
+        // suffix (double dash) qualifies, not the ambiguous single-dash
+        // Docker convention ":latest".
+        assertFalse(VoltDBContainer.isMutableTag("nginx:latest"),
+                "A tag of :latest (single dash) must not be classified as mutable");
+    }
+
+    @Test
+    public void nullImageIsNotMutable() {
+        assertFalse(VoltDBContainer.isMutableTag(null),
+                "A null image reference must not be classified as mutable");
+    }
+}

--- a/volt-testcontainer/src/test/java/PullPolicyIT.java
+++ b/volt-testcontainer/src/test/java/PullPolicyIT.java
@@ -16,10 +16,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@link VoltDBContainer} applies an always-pull image pull policy at
  * construction time.
  *
- * <p>Mutable tags (ending in {@code --latest}) must return {@code true} so
- * that the container is forced to re-pull on every run; every other tag shape
- * must return {@code false} so that pinned tags keep the testcontainers
- * default (pull only when absent locally).
+ * <p>Mutable tags (rolling names whose registry digest can change without
+ * the tag string changing) must return {@code true} so that the container
+ * is forced to re-pull on every run; every other tag shape must return
+ * {@code false} so that pinned tags keep the testcontainers default (pull
+ * only when absent locally).
  *
  * <p>Placed as a failsafe integration test ({@code *IT.java}) because the
  * module's pom configures failsafe only. No Docker daemon interaction is
@@ -28,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class PullPolicyIT {
 
     @Test
-    public void latestSuffixIsMutable() {
+    public void perBranchLatestSuffixIsMutable() {
         assertTrue(VoltDBContainer.isMutableTag("voltdb/voltdb-enterprise-dev:never-released--latest"),
                 "A tag ending in --latest must be classified as mutable");
         assertTrue(VoltDBContainer.isMutableTag("some-image:main--latest"),
@@ -36,20 +37,46 @@ public class PullPolicyIT {
     }
 
     @Test
-    public void pinnedTagIsNotMutable() {
-        assertFalse(VoltDBContainer.isMutableTag("voltdb/voltdb-enterprise:14.3.3"),
-                "A pinned version tag must not be classified as mutable");
-        assertFalse(VoltDBContainer.isMutableTag("voltdb/voltdb-enterprise:master--debug-1234"),
-                "A build-number tag must not be classified as mutable");
+    public void perBranchDebugSuffixIsMutable() {
+        assertTrue(VoltDBContainer.isMutableTag("voltdb/voltdb-enterprise:master--debug"),
+                "A per-branch --debug tag published by 1_pre_check_and_build must be mutable");
+        assertTrue(VoltDBContainer.isMutableTag("voltdb/voltdb-enterprise:release-13.3.x--debug"),
+                "Any branch prefix followed by --debug must be mutable");
     }
 
     @Test
-    public void bareLatestIsNotMutable() {
-        // The classification is intentionally strict: only the "--latest"
-        // suffix (double dash) qualifies, not the ambiguous single-dash
-        // Docker convention ":latest".
-        assertFalse(VoltDBContainer.isMutableTag("nginx:latest"),
-                "A tag of :latest (single dash) must not be classified as mutable");
+    public void perBranchDevSuffixIsMutable() {
+        assertTrue(VoltDBContainer.isMutableTag("voltdb/voltdb-vmc-svc-dev:master--dev"),
+                "A per-branch --dev tag (VMC-svc / legacy) must be mutable");
+    }
+
+    @Test
+    public void globalLatestIsMutable() {
+        assertTrue(VoltDBContainer.isMutableTag("voltdb/voltdb-vmc-svc-dev:latest"),
+                "Docker's global :latest tag must be mutable");
+        assertTrue(VoltDBContainer.isMutableTag("nginx:latest"),
+                "Any :latest tag must be mutable, including third-party images");
+    }
+
+    @Test
+    public void pinnedTagIsNotMutable() {
+        assertFalse(VoltDBContainer.isMutableTag("voltdb/voltdb-enterprise:15.3.0"),
+                "A pinned version tag must not be classified as mutable");
+        assertFalse(VoltDBContainer.isMutableTag("voltdb/voltdb-enterprise:master--142"),
+                "A per-branch build-number tag must not be classified as mutable");
+        assertFalse(VoltDBContainer.isMutableTag("voltdb/voltdb-enterprise:master--debug-142"),
+                "A per-branch --debug-<build> tag is immutable and must not be classified as mutable");
+    }
+
+    @Test
+    public void repoNameContainingMutableSubstringIsNotMutable() {
+        // The classification is a suffix match on the whole image reference,
+        // not a substring search. "voltdb-dev" in the repository name must
+        // not be enough to mark a pinned tag as mutable.
+        assertFalse(VoltDBContainer.isMutableTag("voltdb/voltdb-enterprise-dev:15.3.0"),
+                "Repo names that contain -dev must not affect the classification");
+        assertFalse(VoltDBContainer.isMutableTag("voltdb/voltdb-enterprise-dev:master--142"),
+                "Repo names that contain -dev must not affect the classification");
     }
 
     @Test

--- a/volt-testcontainer/src/test/java/TestBase.java
+++ b/volt-testcontainer/src/test/java/TestBase.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestBase {
 
     /** Default enterprise image used by most tests. */
-    public static final String VOLTDB_IMAGE = "voltdb/voltdb-enterprise:14.3.3";
+    public static final String VOLTDB_IMAGE = "voltdb/voltdb-enterprise:15.3.0";
 
     /** Path to a valid VoltDB license file, resolved from well-known locations. */
     protected static final String validLicensePath;


### PR DESCRIPTION
The containerized upgrade tests in internal
(TestLocalContainerizedClusterUpgrade,
TestLocalContainerizedClusterUpgradeWithCapabilityChecks) failed on master for roughly 28 consecutive builds because the arm64 CI agents kept using a locally cached copy of
voltdb/voltdb-enterprise-dev:never-released--latest that predated new capability ids added on master. 

Fix: at construction time in VoltDBContainer, if the image tag ends in "--latest" call withImagePullPolicy(PullPolicy.alwaysPull()). Pinned immutable tags (e.g. master--debug-NNNN, 14.3.3) keep the testcontainers default so tests don't re-pull on every invocation.


PullPolicyIT covers the classification:
  - "*--latest" -> mutable
  - pinned version tag -> not mutable
  - build-number tag ("master--debug-1234") -> not mutable
  - ":latest" single-dash convention -> not mutable (strict match)
  - null -> not mutable

